### PR TITLE
🎨 Change font-size to 0.85em

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -81,7 +81,7 @@ a:not([class]) {
 
 code {
   font-family: $mono-font-family;
-  font-size: 0.75em;
+  font-size: 0.85em;
   line-height: $body-line-height;
 }
 


### PR DESCRIPTION
- `code`要素のフォントサイズを0.75emから0.85emに変更しました。
    テーマ自体は日本語が書かれることを想定してcssを設定してないだろうと思われるため、zennのcssを参考にした。
