### PR TITLE
<html lang="ja">にする

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ title: MizLab Docs
 description: Docs for MizLab
 baseurl: "/mizlab-docs" # the subpath of your site, e.g. /blog
 url: "https://MizLab.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+lang: "ja"
 
 permalink: pretty
 exclude: ["node_modules/", "*.gemspec", "*.gem", "Gemfile", "Gemfile.lock", "package.json", "package-lock.json",  "script/", "LICENSE.txt", "lib/", "bin/", "README.md", "Rakefile"


### PR DESCRIPTION
Google(Chrome) だと html の中身をみて解釈するから翻訳の提案はしてこないが、他のブラウザだと出るかもしれないので一応設定する。
(現状は`<html lang="en-US">`になっている)
